### PR TITLE
fix: check if container before remove child

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -107,7 +107,9 @@ Notification.newInstance = function newNotificationInstance(properties) {
     component: notification,
     destroy() {
       ReactDOM.unmountComponentAtNode(div);
-      document.body.removeChild(div);
+      if (!getContainer) {
+        document.body.removeChild(div);
+      }
     },
   };
 };


### PR DESCRIPTION
If there's no check for no container, `document.body.removeChild(div);`, will result in an error:

```
DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

Because it's trying to remove the node it presumes on the body.