### PR TITLE
Handle Can not read property 'add' of null

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -102,6 +102,9 @@ Notification.newInstance = function newNotificationInstance(properties, callback
       return;
     }
     called = true;
+    if (notification === null) {
+      return;
+    }
     callback({
       notice(noticeProps) {
         notification.add(noticeProps);


### PR DESCRIPTION
Handle Can not read property 'add' of null that occurred in react16