### PR TITLE
Add ability to update notification props by key

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -49,11 +49,37 @@ function manualClose() {
   });
 }
 
+let counter = 0;
+let intervalKey;
+function updatableFn() {
+  if (counter !== 0) {
+    return;
+  }
+
+  const key = 'updatable-notification';
+  const initialProps = {
+    content: `Timer: ${counter}s`,
+    key,
+    duration: null,
+    closable: true,
+    onClose() {
+      clearInterval(intervalKey);
+      counter = 0;
+    },
+  };
+
+  notification.notice(initialProps);
+  intervalKey = setInterval(() => {
+    notification.notice({ ...initialProps, content: `Timer: ${++counter}s` });
+  }, 1000);
+}
+
 ReactDOM.render(<div>
   <div>
     <button onClick={simpleFn}>simple show</button>
     <button onClick={durationFn}>duration=0</button>
     <button onClick={closableFn}>closable</button>
     <button onClick={manualClose}>controlled close</button>
+    <button onClick={updatableFn}>updatable</button>
   </div>
 </div>, document.getElementById('__react-content'));

--- a/src/Notice.jsx
+++ b/src/Notice.jsx
@@ -24,6 +24,12 @@ export default class Notice extends Component {
     this.startCloseTimer();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.duration !== prevProps.duration) {
+      this.restartCloseTimer();
+    }
+  }
+
   componentWillUnmount() {
     this.clearCloseTimer();
   }
@@ -46,6 +52,11 @@ export default class Notice extends Component {
       clearTimeout(this.closeTimer);
       this.closeTimer = null;
     }
+  }
+
+  restartCloseTimer() {
+    this.clearCloseTimer();
+    this.startCloseTimer();
   }
 
   render() {

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -47,11 +47,17 @@ class Notification extends Component {
     const key = notice.key = notice.key || getUuid();
     this.setState(previousState => {
       const notices = previousState.notices;
-      if (!notices.filter(v => v.key === key).length) {
-        return {
-          notices: notices.concat(notice),
-        };
+      const noticeIndex = notices.map(v => v.key).indexOf(key);
+      let updatedNotices;
+      if (noticeIndex === -1) {
+        updatedNotices = notices.concat(notice);
+      } else {
+        updatedNotices = notices.concat();
+        updatedNotices.splice(noticeIndex, 1, notice);
       }
+      return {
+        notices: updatedNotices,
+      };
     });
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -130,6 +130,44 @@ describe('rc-notification', () => {
     });
   });
 
+  it('update notification by key with multi instance', (done) => {
+    Notification.newInstance({}, notification => {
+      const key = 'updatable';
+      const value = 'value';
+      const notUpdatableValue = 'not-updatable-value';
+      notification.notice({
+        content: <p id="not-updatable" className="not-updatable">{notUpdatableValue}</p>,
+        duration: null,
+      });
+      notification.notice({
+        content: <p id="updatable" className="updatable">{`${value}-old`}</p>,
+        key,
+        duration: null,
+      });
+      notification.notice({
+        content: <p id="updatable" className="updatable">{value}</p>,
+        key,
+        duration: 0.1,
+      });
+
+      setTimeout(() => {
+        // Text updated successfully
+        expect(document.querySelectorAll('.updatable').length).to.be(1);
+        expect(document.querySelector('.updatable').innerText).to.be(value);
+
+        setTimeout(() => {
+          // Other notices are not affected
+          expect(document.querySelectorAll('.not-updatable').length).to.be(1);
+          expect(document.querySelector('.not-updatable').innerText).to.be(notUpdatableValue);
+          // Duration updated successfully
+          expect(document.querySelectorAll('.updatable').length).to.be(0);
+          notification.destroy();
+          done();
+        }, 500);
+      }, 10);
+    });
+  });
+
   it('freeze notification layer when mouse over', (done) => {
     Notification.newInstance({}, notification => {
       notification.notice({

--- a/tests/index.js
+++ b/tests/index.js
@@ -134,36 +134,43 @@ describe('rc-notification', () => {
     Notification.newInstance({}, notification => {
       const key = 'updatable';
       const value = 'value';
+      const newValue = `new-${value}`;
       const notUpdatableValue = 'not-updatable-value';
       notification.notice({
         content: <p id="not-updatable" className="not-updatable">{notUpdatableValue}</p>,
         duration: null,
       });
       notification.notice({
-        content: <p id="updatable" className="updatable">{`${value}-old`}</p>,
+        content: <p id="updatable" className="updatable">{value}</p>,
         key,
         duration: null,
       });
-      notification.notice({
-        content: <p id="updatable" className="updatable">{value}</p>,
-        key,
-        duration: 0.1,
-      });
 
       setTimeout(() => {
-        // Text updated successfully
         expect(document.querySelectorAll('.updatable').length).to.be(1);
         expect(document.querySelector('.updatable').innerText).to.be(value);
 
+        notification.notice({
+          content: <p id="updatable" className="updatable">{newValue}</p>,
+          key,
+          duration: 0.1,
+        });
+
         setTimeout(() => {
-          // Other notices are not affected
-          expect(document.querySelectorAll('.not-updatable').length).to.be(1);
-          expect(document.querySelector('.not-updatable').innerText).to.be(notUpdatableValue);
-          // Duration updated successfully
-          expect(document.querySelectorAll('.updatable').length).to.be(0);
-          notification.destroy();
-          done();
-        }, 500);
+          // Text updated successfully
+          expect(document.querySelectorAll('.updatable').length).to.be(1);
+          expect(document.querySelector('.updatable').innerText).to.be(newValue);
+
+          setTimeout(() => {
+            // Other notices are not affected
+            expect(document.querySelectorAll('.not-updatable').length).to.be(1);
+            expect(document.querySelector('.not-updatable').innerText).to.be(notUpdatableValue);
+            // Duration updated successfully
+            expect(document.querySelectorAll('.updatable').length).to.be(0);
+            notification.destroy();
+            done();
+          }, 500);
+        }, 10);
       }, 10);
     });
   });


### PR DESCRIPTION
Hey guys, 
thank you for such small and useful library to manage notification messages.
I'm using it for my current project and like it very much.
I faced the situation when our UX requires an ability to update rendered notice content. Unfortunately, all my tries to update notification using its key failed. That is why I dug into the code and make a small update to be able to update rendered notice properties.

I've added required changes, example, test.
Here how it looks like:

![updatable-notice](https://user-images.githubusercontent.com/8986191/38336671-fc2cd4fc-3838-11e8-99f5-299b49869104.gif)
