### PR TITLE
add max number of notices show

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build
 lib
 es
 coverage
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ props details:
           <td> { right: '50%' } </td>
           <td>additional style for single notice node.</td>
         </tr>
+        <tr>
+          <td>maxItems</td>
+          <td>number</td>
+          <td>99</td>
+          <td>max notices show, update last if exceed limit</td>
+        </tr>
     </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ props details:
           <td>additional style for single notice node.</td>
         </tr>
         <tr>
-          <td>maxItems</td>
+          <td>maxCount</td>
           <td>number</td>
-          <td>99</td>
-          <td>max notices show, update last if exceed limit</td>
+          <td></td>
+          <td>max notices show, drop first notice if exceed limit</td>
         </tr>
     </tbody>
 </table>

--- a/src/Notice.jsx
+++ b/src/Notice.jsx
@@ -7,6 +7,7 @@ export default class Notice extends Component {
     duration: PropTypes.number,
     onClose: PropTypes.func,
     children: PropTypes.any,
+    update: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -25,7 +26,8 @@ export default class Notice extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.duration !== prevProps.duration) {
+    if (this.props.duration !== prevProps.duration
+      || this.props.update) {
       this.restartCloseTimer();
     }
   }

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -19,6 +19,7 @@ class Notification extends Component {
     transitionName: PropTypes.string,
     animation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     style: PropTypes.object,
+    maxItems: PropTypes.number,
   };
 
   static defaultProps = {
@@ -28,6 +29,7 @@ class Notification extends Component {
       top: 65,
       left: '50%',
     },
+    maxItems: 99,
   };
 
   state = {
@@ -45,15 +47,21 @@ class Notification extends Component {
 
   add = (notice) => {
     const key = notice.key = notice.key || getUuid();
+    const { maxItems } = this.props;
     this.setState(previousState => {
       const notices = previousState.notices;
       const noticeIndex = notices.map(v => v.key).indexOf(key);
-      let updatedNotices;
-      if (noticeIndex === -1) {
-        updatedNotices = notices.concat(notice);
-      } else {
-        updatedNotices = notices.concat();
+      const updatedNotices = notices.concat();
+      if (noticeIndex !== -1) {
         updatedNotices.splice(noticeIndex, 1, notice);
+      } else {
+        if (notices.length < maxItems) {
+          updatedNotices.push(notice);
+        } else {
+          notice.key = updatedNotices[maxItems - 1].key;
+          notice.update = true;
+          updatedNotices[maxItems - 1] = notice;
+        }
       }
       return {
         notices: updatedNotices,

--- a/tests/index.js
+++ b/tests/index.js
@@ -220,4 +220,28 @@ describe('rc-notification', () => {
     expect(() => ReactDOM.render(<Test />, container))
       .to.not.throwException();
   });
+
+  it('update last notice when items limit exceeds', (done) => {
+    Notification.newInstance({ maxItems: 1 }, notification => {
+      const value = 'updated last';
+      notification.notice({
+        content: <span className="test-maxitems">simple show</span>,
+        duration: 3,
+      });
+      notification.notice({
+        content: <span className="test-maxitems">simple show</span>,
+        duration: 3,
+      });
+      notification.notice({
+        content: <span className="test-maxitems">{value}</span>,
+        duration: 3,
+      });
+
+      setTimeout(() => {
+        expect(document.querySelectorAll('.test-maxitems').length).to.be(1);
+        expect(document.querySelector('.test-maxitems').innerText).to.be(value);
+        done();
+      }, 10);
+    });
+  });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -221,25 +221,25 @@ describe('rc-notification', () => {
       .to.not.throwException();
   });
 
-  it('update last notice when items limit exceeds', (done) => {
-    Notification.newInstance({ maxItems: 1 }, notification => {
+  it('drop first notice when items limit exceeds', (done) => {
+    Notification.newInstance({ maxCount: 1 }, notification => {
       const value = 'updated last';
       notification.notice({
-        content: <span className="test-maxitems">simple show</span>,
+        content: <span className="test-maxcount">simple show</span>,
         duration: 3,
       });
       notification.notice({
-        content: <span className="test-maxitems">simple show</span>,
+        content: <span className="test-maxcount">simple show</span>,
         duration: 3,
       });
       notification.notice({
-        content: <span className="test-maxitems">{value}</span>,
+        content: <span className="test-maxcount">{value}</span>,
         duration: 3,
       });
 
       setTimeout(() => {
-        expect(document.querySelectorAll('.test-maxitems').length).to.be(1);
-        expect(document.querySelector('.test-maxitems').innerText).to.be(value);
+        expect(document.querySelectorAll('.test-maxcount').length).to.be(1);
+        expect(document.querySelector('.test-maxcount').innerText).to.be(value);
         done();
       }, 10);
     });


### PR DESCRIPTION
To help fix https://github.com/ant-design/ant-design/issues/9198 , add a maxItems prop to set max number of notices show in current page. Update last item using same key if limit exceeded to avoid occasional flicker.