### PR TITLE
Render aria and data props as attributes

### DIFF
--- a/src/Notice.jsx
+++ b/src/Notice.jsx
@@ -69,9 +69,19 @@ export default class Notice extends Component {
       [`${componentClass}-closable`]: props.closable,
       [props.className]: !!props.className,
     };
+    const dataOrAriaAttributeProps = Object.keys(props).reduce((prev, key) => {
+      if ((key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role')) {
+        prev[key] = props[key];
+      }
+      return prev;
+    }, {});
     return (
-      <div className={classNames(className)} style={props.style} onMouseEnter={this.clearCloseTimer}
+      <div
+        className={classNames(className)}
+        style={props.style}
+        onMouseEnter={this.clearCloseTimer}
         onMouseLeave={this.startCloseTimer}
+        {...dataOrAriaAttributeProps}
       >
         <div className={`${componentClass}-content`}>{props.children}</div>
           {props.closable ?

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -90,6 +90,7 @@ class Notification extends Component {
         key={key}
         update={update}
         onClose={onClose}
+        {...notice.props}
       >
         {notice.content}
       </Notice>);

--- a/tests/index.js
+++ b/tests/index.js
@@ -244,4 +244,68 @@ describe('rc-notification', () => {
       }, 10);
     });
   });
+
+  describe('data and aria props', () => {
+    it('sets data attributes', (done) => {
+      Notification.newInstance({}, notification => {
+        notification.notice({
+          content: <span className="test-data-attributes">simple show</span>,
+          duration: 3,
+          className: 'notice-class',
+          props: {
+            'data-test': 'test-id',
+            'data-id': '12345',
+          },
+        });
+
+        setTimeout(() => {
+          const notices = document.querySelectorAll('.notice-class');
+          expect(notices.length).to.be(1);
+          expect(notices[0].getAttribute('data-test')).to.be('test-id');
+          expect(notices[0].getAttribute('data-id')).to.be('12345');
+          done();
+        }, 10);
+      });
+    });
+
+    it('sets aria attributes', (done) => {
+      Notification.newInstance({}, notification => {
+        notification.notice({
+          content: <span className="test-aria-attributes">simple show</span>,
+          duration: 3,
+          className: 'notice-class',
+          props: {
+            'aria-describedby': 'described-id',
+            'aria-labelledby': 'label-id',
+          },
+        });
+
+        setTimeout(() => {
+          const notices = document.querySelectorAll('.notice-class');
+          expect(notices.length).to.be(1);
+          expect(notices[0].getAttribute('aria-describedby')).to.be('test-id');
+          expect(notices[0].getAttribute('aria-labelledby')).to.be('label-id');
+          done();
+        }, 10);
+      });
+    });
+
+    it('sets role attribute', (done) => {
+      Notification.newInstance({}, notification => {
+        notification.notice({
+          content: <span className="test-aria-attributes">simple show</span>,
+          duration: 3,
+          className: 'notice-class',
+          props: { role: 'alert' },
+        });
+
+        setTimeout(() => {
+          const notices = document.querySelectorAll('.notice-class');
+          expect(notices.length).to.be(1);
+          expect(notices[0].getAttribute('role')).to.be('alert');
+          done();
+        }, 10);
+      });
+    });
+  });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -251,7 +251,7 @@ describe('rc-notification', () => {
         notification.notice({
           content: <span className="test-data-attributes">simple show</span>,
           duration: 3,
-          className: 'notice-class',
+          className: 'test-data-class',
           props: {
             'data-test': 'test-id',
             'data-id': '12345',
@@ -259,7 +259,7 @@ describe('rc-notification', () => {
         });
 
         setTimeout(() => {
-          const notices = document.querySelectorAll('.notice-class');
+          const notices = document.querySelectorAll('.test-data-class');
           expect(notices.length).to.be(1);
           expect(notices[0].getAttribute('data-test')).to.be('test-id');
           expect(notices[0].getAttribute('data-id')).to.be('12345');
@@ -273,7 +273,7 @@ describe('rc-notification', () => {
         notification.notice({
           content: <span className="test-aria-attributes">simple show</span>,
           duration: 3,
-          className: 'notice-class',
+          className: 'test-aria-class',
           props: {
             'aria-describedby': 'described-id',
             'aria-labelledby': 'label-id',
@@ -281,9 +281,9 @@ describe('rc-notification', () => {
         });
 
         setTimeout(() => {
-          const notices = document.querySelectorAll('.notice-class');
+          const notices = document.querySelectorAll('.test-aria-class');
           expect(notices.length).to.be(1);
-          expect(notices[0].getAttribute('aria-describedby')).to.be('test-id');
+          expect(notices[0].getAttribute('aria-describedby')).to.be('described-id');
           expect(notices[0].getAttribute('aria-labelledby')).to.be('label-id');
           done();
         }, 10);
@@ -295,12 +295,12 @@ describe('rc-notification', () => {
         notification.notice({
           content: <span className="test-aria-attributes">simple show</span>,
           duration: 3,
-          className: 'notice-class',
+          className: 'test-role-class',
           props: { role: 'alert' },
         });
 
         setTimeout(() => {
-          const notices = document.querySelectorAll('.notice-class');
+          const notices = document.querySelectorAll('.test-role-class');
           expect(notices.length).to.be(1);
           expect(notices[0].getAttribute('role')).to.be('alert');
           done();


### PR DESCRIPTION
Passes `data-*`, `aria-*`, and `role` props to `Notice` to render as html attributes.