### PR TITLE
feat: Render aria and data props

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ props details:
           <td></td>
           <td>specific the close icon.</td>
         </tr>
+        <tr>
+          <td>props</td>
+          <td>Object</td>
+          <td></td>
+          <td>An object that can contain <code>data-*</code>, <code>aria-*</code>, or <code>role</code> props, to be put on the notification <code>div</code>. This currently only allows <code>data-testid</code> instead of <code>data-*</code> in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/examples/hooks.tsx
+++ b/examples/hooks.tsx
@@ -31,6 +31,9 @@ const Demo = () => {
           notice({
             ...NOTICE,
             content: <Context.Consumer>{({ name }) => `Hi ${name}!`}</Context.Consumer>,
+            props: {
+              'data-testid': 'my-data-testid',
+            },
           });
           notificationInstance.notice({ ...NOTICE });
         }}

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
+interface DivProps extends React.HTMLProps<HTMLDivElement> {
+  // Ideally we would allow all data-* props but this would depend on https://github.com/microsoft/TypeScript/issues/28960
+  'data-testid'?: string;
+}
+
 export interface NoticeProps {
   prefixCls: string;
   style?: React.CSSProperties;
@@ -11,6 +16,7 @@ export interface NoticeProps {
   update?: boolean;
   closeIcon?: React.ReactNode;
   closable?: boolean;
+  props?: DivProps;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onClose?: () => void;
 
@@ -83,6 +89,15 @@ export default class Notice extends Component<NoticeProps> {
       holder,
     } = this.props;
     const componentClass = `${prefixCls}-notice`;
+    const dataOrAriaAttributeProps = Object.keys(this.props).reduce(
+      (acc: { [key: string]: string }, key: string) => {
+        if (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role') {
+          acc[key] = this.props[key];
+        }
+        return acc;
+      },
+      {},
+    );
     const node = (
       <div
         className={classNames(componentClass, className, {
@@ -92,6 +107,7 @@ export default class Notice extends Component<NoticeProps> {
         onMouseEnter={this.clearCloseTimer}
         onMouseLeave={this.startCloseTimer}
         onClick={onClick}
+        {...dataOrAriaAttributeProps}
       >
         <div className={`${componentClass}-content`}>{children}</div>
         {closable ? (

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -131,6 +131,7 @@ class Notification extends Component<NotificationProps, NotificationState> {
         prefixCls,
         closeIcon,
         ...notice,
+        ...notice.props,
         key,
         update,
         onClose,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -413,4 +413,69 @@ describe('Notification.Basic', () => {
       },
     );
   });
+
+  it('sets data attributes', done => {
+    Notification.newInstance({}, notification => {
+      notification.notice({
+        content: <span className="test-data-attributes">simple show</span>,
+        duration: 3,
+        className: 'notice-class',
+        props: {
+          'data-test': 'data-test-value',
+          'data-testid': 'data-testid-value',
+        },
+      });
+
+      setTimeout(() => {
+        const notice = document.querySelectorAll('.notice-class');
+        expect(notice.length).toBe(1);
+        expect(notice[0].getAttribute('data-test')).toBe('data-test-value');
+        expect(notice[0].getAttribute('data-testid')).toBe('data-testid-value');
+        notification.destroy();
+        done();
+      }, 10);
+    });
+  });
+
+  it('sets aria attributes', done => {
+    Notification.newInstance({}, notification => {
+      notification.notice({
+        content: <span className="test-aria-attributes">simple show</span>,
+        duration: 3,
+        className: 'notice-class',
+        props: {
+          'aria-describedby': 'aria-describedby-value',
+          'aria-labelledby': 'aria-labelledby-value',
+        },
+      });
+
+      setTimeout(() => {
+        const notice = document.querySelectorAll('.notice-class');
+        expect(notice.length).toBe(1);
+        expect(notice[0].getAttribute('aria-describedby')).toBe('aria-describedby-value');
+        expect(notice[0].getAttribute('aria-labelledby')).toBe('aria-labelledby-value');
+        notification.destroy();
+        done();
+      }, 10);
+    });
+  });
+
+  it('sets role attribute', done => {
+    Notification.newInstance({}, notification => {
+      notification.notice({
+        content: <span className="test-aria-attributes">simple show</span>,
+        duration: 3,
+        className: 'notice-class',
+        props: { role: 'alert' },
+      });
+
+      setTimeout(() => {
+        const notice = document.querySelectorAll('.notice-class');
+        expect(notice.length).toBe(1);
+        expect(notice[0].getAttribute('role')).toBe('alert');
+        notification.destroy();
+        done();
+      }, 10);
+    });
+  });
 });


### PR DESCRIPTION
*Rebase of: https://github.com/react-component/notification/pull/43*

Passes data-*, aria-*, and role props to Notice to render as html attributes.