### PR TITLE
fix: Should reset when motion end

### DIFF
--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -25,6 +25,9 @@ export interface NoticeProps {
 
   /** @private Only for internal usage. We don't promise that we will refactor this */
   holder?: HTMLDivElement;
+
+  /** @private Provided by CSSMotionList */
+  visible?: boolean;
 }
 
 export default class Notice extends Component<NoticeProps> {
@@ -42,7 +45,8 @@ export default class Notice extends Component<NoticeProps> {
   componentDidUpdate(prevProps: NoticeProps) {
     if (
       this.props.duration !== prevProps.duration ||
-      this.props.updateMark !== prevProps.updateMark
+      this.props.updateMark !== prevProps.updateMark ||
+      this.props.visible !== prevProps.visible
     ) {
       this.restartCloseTimer();
     }
@@ -84,16 +88,8 @@ export default class Notice extends Component<NoticeProps> {
   }
 
   render() {
-    const {
-      prefixCls,
-      className,
-      closable,
-      closeIcon,
-      style,
-      onClick,
-      children,
-      holder,
-    } = this.props;
+    const { prefixCls, className, closable, closeIcon, style, onClick, children, holder } =
+      this.props;
     const componentClass = `${prefixCls}-notice`;
     const dataOrAriaAttributeProps = Object.keys(this.props).reduce(
       (acc: Record<string, string>, key: string) => {

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -46,7 +46,8 @@ export default class Notice extends Component<NoticeProps> {
     if (
       this.props.duration !== prevProps.duration ||
       this.props.updateMark !== prevProps.updateMark ||
-      this.props.visible !== prevProps.visible
+      // Visible again need reset timer
+      (this.props.visible !== prevProps.visible && this.props.visible)
     ) {
       this.restartCloseTimer();
     }

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -192,7 +192,7 @@ class Notification extends Component<NotificationProps, NotificationState> {
             }
           }}
         >
-          {({ key, className: motionClassName, style: motionStyle }) => {
+          {({ key, className: motionClassName, style: motionStyle, visible }) => {
             const { props: noticeProps, holderCallback } = this.noticePropsMap[key];
             if (holderCallback) {
               return (
@@ -221,6 +221,7 @@ class Notification extends Component<NotificationProps, NotificationState> {
                 {...noticeProps}
                 className={classNames(motionClassName, noticeProps?.className)}
                 style={{ ...motionStyle, ...noticeProps?.style }}
+                visible={visible}
               />
             );
           }}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,16 +6,16 @@ import Notification from '../src';
 require('../assets/index.less');
 
 describe('Notification.Basic', () => {
-  it('works', done => {
+  it('works', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: <p className="test">1</p>,
           duration: 0.1,
@@ -34,17 +34,17 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('works with custom close icon', done => {
+  it('works with custom close icon', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
         closeIcon: <span className="test-icon">test-close-icon</span>,
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: <p className="test">1</p>,
           closable: true,
@@ -59,16 +59,16 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('works with multi instance', done => {
+  it('works with multi instance', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: <p className="test">1</p>,
           duration: 0.1,
@@ -91,7 +91,7 @@ describe('Notification.Basic', () => {
   });
 
   it('destroy works', () => {
-    Notification.newInstance({}, notification => {
+    Notification.newInstance({}, (notification) => {
       notification.notice({
         content: (
           <p id="test" className="test">
@@ -119,7 +119,7 @@ describe('Notification.Basic', () => {
       {
         getContainer: () => document.getElementById('get-container-test'),
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: (
             <p id="test" className="test">
@@ -136,18 +136,18 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('remove notify works', done => {
+  it('remove notify works', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         const key = Date.now();
-        const close = k => {
+        const close = (k) => {
           notification.removeNotice(k);
         };
         notification.notice({
@@ -176,16 +176,16 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('update notification by key with multi instance', done => {
+  it('update notification by key with multi instance', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         const key = 'updatable';
         const value = 'value';
         const newValue = `new-${value}`;
@@ -244,16 +244,16 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('freeze notification layer when mouse over', done => {
+  it('freeze notification layer when mouse over', (done) => {
     let wrapper;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: (
             <p id="freeze" className="freeze">
@@ -285,7 +285,7 @@ describe('Notification.Basic', () => {
   it('should work in lifecycle of React component', () => {
     class Test extends React.Component {
       componentDidMount() {
-        Notification.newInstance({}, notification => {
+        Notification.newInstance({}, (notification) => {
           notification.notice({
             content: <span>In lifecycle</span>,
           });
@@ -302,17 +302,17 @@ describe('Notification.Basic', () => {
   });
 
   describe('maxCount', () => {
-    it('remove work when maxCount set', done => {
+    it('remove work when maxCount set', (done) => {
       let wrapper;
 
       Notification.newInstance(
         {
-          TEST_RENDER: node => {
+          TEST_RENDER: (node) => {
             wrapper = mount(<div>{node}</div>);
           },
           maxCount: 1,
         },
-        notification => {
+        (notification) => {
           // First
           notification.notice({
             content: <div className="max-count">bamboo</div>,
@@ -351,11 +351,11 @@ describe('Notification.Basic', () => {
       Notification.newInstance(
         {
           maxCount: 1,
-          TEST_RENDER: node => {
+          TEST_RENDER: (node) => {
             wrapper = mount(<div>{node}</div>);
           },
         },
-        notification => {
+        (notification) => {
           notificationInstance = notification;
         },
       );
@@ -385,18 +385,18 @@ describe('Notification.Basic', () => {
       jest.useRealTimers();
     });
 
-    it('duration should work', done => {
+    it('duration should work', (done) => {
       let wrapper;
 
       let notificationInstance;
       Notification.newInstance(
         {
           maxCount: 1,
-          TEST_RENDER: node => {
+          TEST_RENDER: (node) => {
             wrapper = mount(<div>{node}</div>);
           },
         },
-        notification => {
+        (notification) => {
           notificationInstance = notification;
 
           notificationInstance.notice({
@@ -430,19 +430,19 @@ describe('Notification.Basic', () => {
     });
   });
 
-  it('onClick trigger', done => {
+  it('onClick trigger', (done) => {
     let wrapper;
     let clicked = 0;
 
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         const key = Date.now();
-        const close = k => {
+        const close = (k) => {
           notification.removeNotice(k);
         };
         notification.notice({
@@ -461,10 +461,7 @@ describe('Notification.Basic', () => {
         });
 
         setTimeout(() => {
-          wrapper
-            .find('.rc-notification-notice')
-            .last()
-            .simulate('click');
+          wrapper.find('.rc-notification-notice').last().simulate('click');
           expect(clicked).toEqual(1);
           notification.destroy();
           done();
@@ -473,17 +470,17 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('Close Notification only trigger onClose', done => {
+  it('Close Notification only trigger onClose', (done) => {
     let wrapper;
     let clickCount = 0;
     let closeCount = 0;
     Notification.newInstance(
       {
-        TEST_RENDER: node => {
+        TEST_RENDER: (node) => {
           wrapper = mount(<div>{node}</div>);
         },
       },
-      notification => {
+      (notification) => {
         notification.notice({
           content: <p className="test">1</p>,
           closable: true,
@@ -496,10 +493,7 @@ describe('Notification.Basic', () => {
         });
 
         setTimeout(() => {
-          wrapper
-            .find('.rc-notification-notice-close')
-            .last()
-            .simulate('click');
+          wrapper.find('.rc-notification-notice-close').last().simulate('click');
           expect(clickCount).toEqual(0);
           expect(closeCount).toEqual(1);
           notification.destroy();
@@ -509,8 +503,8 @@ describe('Notification.Basic', () => {
     );
   });
 
-  it('sets data attributes', done => {
-    Notification.newInstance({}, notification => {
+  it('sets data attributes', (done) => {
+    Notification.newInstance({}, (notification) => {
       notification.notice({
         content: <span className="test-data-attributes">simple show</span>,
         duration: 3,
@@ -532,8 +526,8 @@ describe('Notification.Basic', () => {
     });
   });
 
-  it('sets aria attributes', done => {
-    Notification.newInstance({}, notification => {
+  it('sets aria attributes', (done) => {
+    Notification.newInstance({}, (notification) => {
       notification.notice({
         content: <span className="test-aria-attributes">simple show</span>,
         duration: 3,
@@ -555,8 +549,8 @@ describe('Notification.Basic', () => {
     });
   });
 
-  it('sets role attribute', done => {
-    Notification.newInstance({}, notification => {
+  it('sets role attribute', (done) => {
+    Notification.newInstance({}, (notification) => {
       notification.notice({
         content: <span className="test-aria-attributes">simple show</span>,
         duration: 3,


### PR DESCRIPTION
jest 里模拟不出来动画时机比较蛋疼。简单来说就是 Notice 在触发 `close` 时，动画进入消失状态。这个时候如果遇到一个一模一样的 `key` 创建新的元素就会被复用到这个被移除的 Notice 上，导致 Notice 清退被打断。添加一个额外的 `visible` 判断，如果有变化了。就重置一下。

resolve https://github.com/ant-design/ant-design/issues/30742