### PR TITLE
feat: remove unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "rc-motion": "^2.2.0",
     "rc-util": "^5.0.1"


### PR DESCRIPTION
It looks like you don't need to keep `@babel/runtime` as a package dependency.

Potentially, it's possible to remove it from rc-util too.