### PR TITLE
fix: React 17 order miss

### DIFF
--- a/src/useNotification.tsx
+++ b/src/useNotification.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
-import Notifications from './Notifications';
-import type { Placement } from './Notifications';
-import type { NotificationsRef, OpenConfig } from './Notifications';
 import type { CSSMotionProps } from 'rc-motion';
+import * as React from 'react';
+import type { NotificationsRef, OpenConfig, Placement } from './Notifications';
+import Notifications from './Notifications';
 
 const defaultGetContainer = () => document.body;
 
@@ -146,7 +145,12 @@ export default function useNotification(
         }
       });
 
-      setTaskQueue([]);
+      // React 17 will mix order of effect & setState in async
+      // - open: setState[0]
+      // - effect[0]
+      // - open: setState[1]
+      // - effect setState([]) * here will clean up [0, 1] in React 17
+      setTaskQueue((oriQueue) => oriQueue.filter((task) => !taskQueue.includes(task)));
     }
   }, [taskQueue]);
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/43659

和乱序相关，测试里模拟不出来。逻辑是这样子， React 17 的异步里调用 setState 会立刻触发 effect。而在 effect 里调用 setState 又会变成同步模式。导致中间会丢失数据（异步调用两次 open 方法）：

- open: setState[0] > [0]
- effect[0]: 遍历生成 popup
- open: setState[1] > [0, 1]
- setState in effect([])  > []: 在 effect 里只有 [0]，但是 state 里其实中途被塞入个 1，这里却被一起清除了