### PR TITLE
chore: fix bundle size

### DIFF
--- a/src/NoticeList.tsx
+++ b/src/NoticeList.tsx
@@ -83,7 +83,7 @@ const NoticeList: FC<NoticeListProps> = (props) => {
       onAllRemoved={() => {
         onAllNoticeRemoved(placement);
       }}
-      onAppearPrepare={async (element) => {
+      onAppearPrepare={(element) => {
         if (element.parentNode.lastElementChild === element) {
           setLatestNotice(element as HTMLDivElement);
         }


### PR DESCRIPTION
使用 async/await 会导致 webpack 4 打包 regeneratorRuntime 的时候多打包一份 cjs 模块，升级 webpack 5 可以解决，因为 babel 使用了 exports 来指定 import 路径。

这里没有必要使用 async/await，先删除了。