### PR TITLE
fix: notification memory leak

### DIFF
--- a/src/NoticeList.tsx
+++ b/src/NoticeList.tsx
@@ -46,7 +46,7 @@ const NoticeList: FC<NoticeListProps> = (props) => {
   const { classNames: ctxCls } = useContext(NotificationContext);
 
   const dictRef = useRef<Record<string, HTMLDivElement>>({});
-  const [latestNotice, setLatestNotice] = useState<HTMLDivElement>(null);
+  const latestNoticeRef = useRef<HTMLDivElement>(null);
   const [hoverKeys, setHoverKeys] = useState<string[]>([]);
 
   const keys = configList.map((config) => ({
@@ -72,7 +72,7 @@ const NoticeList: FC<NoticeListProps> = (props) => {
   // Force update latest notice
   useEffect(() => {
     if (stack && dictRef.current[keys[keys.length - 1]?.key]) {
-      setLatestNotice(dictRef.current[keys[keys.length - 1]?.key]);
+      latestNoticeRef.current = dictRef.current[keys[keys.length - 1]?.key];
     }
   }, [keys, stack]);
 
@@ -115,7 +115,7 @@ const NoticeList: FC<NoticeListProps> = (props) => {
           if (index > 0) {
             stackStyle.height = expanded
               ? dictRef.current[strKey]?.offsetHeight
-              : latestNotice?.offsetHeight;
+              : latestNoticeRef.current?.offsetHeight;
 
             // Transform
             let verticalOffset = 0;
@@ -126,8 +126,8 @@ const NoticeList: FC<NoticeListProps> = (props) => {
             const transformY =
               (expanded ? verticalOffset : index * offset) * (placement.startsWith('top') ? 1 : -1);
             const scaleX =
-              !expanded && latestNotice?.offsetWidth && dictRef.current[strKey]?.offsetWidth
-                ? (latestNotice?.offsetWidth - offset * 2 * (index < 3 ? index : 3)) /
+              !expanded && latestNoticeRef.current?.offsetWidth && dictRef.current[strKey]?.offsetWidth
+                ? (latestNoticeRef.current?.offsetWidth - offset * 2 * (index < 3 ? index : 3)) /
                   dictRef.current[strKey]?.offsetWidth
                 : 1;
             stackStyle.transform = `translate3d(${transformX}, ${transformY}px, 0) scaleX(${scaleX})`;


### PR DESCRIPTION
## Description
当使用stack时 notification会造成内存泄漏

## Visuals

修改前的dom节点：
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/72418a85-16ea-4b68-a4bf-8f78bbde2a84">


修改后的dom节点：
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/a8660a75-74c1-490a-91bf-7a1eaab2b477">


## Checklist

- [x] My code follows the style guidelines and recommended practices of this project
- [x] I have performed a self-review of my own code and fixed the problems I found
- [x] I have tested my change that my fix is effective or that my feature works, and that it does not break existing functionality.

## Any TODOs?

A summary of any remaining work required to complete the requirements of the task.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了最新通知的处理方式，提高了组件的性能。
- **文档**
	- 更新了导出实体的命名，以反映最新的实现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->