### PR TITLE
关闭按钮a标签修改为button用以无障碍属性实现

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -240,7 +240,7 @@
           }
 
           &::after {
-            content: '';
+            content: "";
             position: absolute;
             left: 0;
             right: 0;
@@ -249,7 +249,7 @@
             height: calc(100% + 32px);
             background: transparent;
             pointer-events: auto;
-            color: rgb(0, 0, 0);
+            color: rgb(0,0,0);
           }
         }
       }

--- a/assets/index.less
+++ b/assets/index.less
@@ -79,6 +79,8 @@
       cursor: pointer;
       opacity: 0.2;
       filter: alpha(opacity=20);
+      border: 0;
+      background-color: #fff;
 
       &-x:after {
         content: '×';
@@ -238,7 +240,7 @@
           }
 
           &::after {
-            content: "";
+            content: '';
             position: absolute;
             left: 0;
             right: 0;
@@ -247,7 +249,7 @@
             height: calc(100% + 32px);
             background: transparent;
             pointer-events: auto;
-            color: rgb(0,0,0);
+            color: rgb(0, 0, 0);
           }
         }
       }

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -144,7 +144,6 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
       {/* Close Icon */}
       {closable && (
         <button
-          tabIndex={0}
           className={`${noticePrefixCls}-close`}
           onKeyDown={onCloseKeyDown}
           aria-label="Close"

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -46,7 +46,7 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
     onNoticeClose(eventKey);
   };
 
-  const onCloseKeyDown: React.KeyboardEventHandler<HTMLAnchorElement> = (e) => {
+  const onCloseKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = (e) => {
     if (e.key === 'Enter' || e.code === 'Enter' || e.keyCode === KeyCode.ENTER) {
       onInternalClose();
     }
@@ -143,8 +143,9 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
 
       {/* Close Icon */}
       {closable && (
-        <a
+        <button
           tabIndex={0}
+          role="button"
           className={`${noticePrefixCls}-close`}
           onKeyDown={onCloseKeyDown}
           aria-label="Close"
@@ -156,7 +157,7 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
           }}
         >
           {closableObj.closeIcon}
-        </a>
+        </button>
       )}
 
       {/* Progress Bar */}

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -27,7 +27,6 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
     eventKey,
     content,
     closable,
-    closeIcon = 'x',
     props: divProps,
 
     onClick,
@@ -106,11 +105,8 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
     if (typeof closable === 'object' && closable !== null) {
       return closable;
     }
-    if (closable) {
-      return { closeIcon };
-    }
     return {};
-  }, [closable, closeIcon]);
+  }, [closable]);
 
   const ariaProps = pickAttrs(closableObj, true);
 
@@ -154,7 +150,7 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
             onInternalClose();
           }}
         >
-          {closableObj.closeIcon}
+          {closableObj?.closeIcon || 'x'}
         </button>
       )}
 

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -150,7 +150,7 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
             onInternalClose();
           }}
         >
-          {closableObj?.closeIcon || 'x'}
+          {closableObj.closeIcon ?? 'x'}
         </button>
       )}
 

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -145,7 +145,6 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
       {closable && (
         <button
           tabIndex={0}
-          role="button"
           className={`${noticePrefixCls}-close`}
           onKeyDown={onCloseKeyDown}
           aria-label="Close"

--- a/src/hooks/useNotification.tsx
+++ b/src/hooks/useNotification.tsx
@@ -14,7 +14,7 @@ export interface NotificationConfig {
   /** Customize container. It will repeat call which means you should return same container element. */
   getContainer?: () => HTMLElement | ShadowRoot;
   motion?: CSSMotionProps | ((placement: Placement) => CSSMotionProps);
-  closeIcon?: React.ReactNode;
+
   closable?: boolean | ({ closeIcon?: React.ReactNode } & React.AriaAttributes);
   maxCount?: number;
   duration?: number;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -9,7 +9,7 @@ export interface NoticeConfig {
   duration?: number | null;
   showProgress?: boolean;
   pauseOnHover?: boolean;
-  closeIcon?: React.ReactNode;
+
   closable?: boolean | ({ closeIcon?: React.ReactNode } & React.AriaAttributes);
   className?: string;
   style?: React.CSSProperties;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -52,14 +52,14 @@ describe('Notification.Basic', () => {
   });
 
   it('works with custom close icon', () => {
-    const { instance } = renderDemo({
-      closeIcon: <span className="test-icon">test-close-icon</span>,
-    });
+    const { instance } = renderDemo();
 
     act(() => {
       instance.open({
         content: <p className="test">1</p>,
-        closable: true,
+        closable: {
+          closeIcon: <span className="test-icon">test-close-icon</span>,
+        },
         duration: 0,
       });
     });
@@ -894,10 +894,10 @@ describe('Notification.Basic', () => {
   });
   it('notification close node ', () => {
     const Demo = () => {
-      const [duration, setDuration] = React.useState(null);
+      const [duration] = React.useState(null);
       const [api, holder] = useNotification({ duration });
       return (
-        <div>
+        <>
           <button
             data-testid="show-notification"
             onClick={() => {
@@ -910,7 +910,7 @@ describe('Notification.Basic', () => {
             show notification
           </button>
           {holder}
-        </div>
+        </>
       );
     };
     const { getByTestId } = render(<Demo />);

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -892,4 +892,32 @@ describe('Notification.Basic', () => {
       expect(document.querySelectorAll('.rc-notification-notice').length).toBe(1);
     });
   });
+  it('notification close node ', () => {
+    const Demo = () => {
+      const [duration, setDuration] = React.useState(null);
+      const [api, holder] = useNotification({ duration });
+      return (
+        <div>
+          <button
+            data-testid="show-notification"
+            onClick={() => {
+              api.open({
+                content: `Test Notification`,
+                closable: { 'aria-label': 'xxx' },
+              });
+            }}
+          >
+            show notification
+          </button>
+          {holder}
+        </div>
+      );
+    };
+    const { getByTestId } = render(<Demo />);
+    fireEvent.click(getByTestId('show-notification'));
+    expect(document.querySelector('button.rc-notification-notice-close')).toHaveAttribute(
+      'aria-label',
+      'xxx',
+    );
+  });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -894,7 +894,7 @@ describe('Notification.Basic', () => {
   });
   it('notification close node ', () => {
     const Demo = () => {
-      const [duration] = React.useState(null);
+      const [duration] = React.useState(0);
       const [api, holder] = useNotification({ duration });
       return (
         <>


### PR DESCRIPTION
修改背景：
antd RFC：https://github.com/ant-design/ant-design/discussions/53197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式**
  - 更新了通知关闭按钮的外观，移除了边框并采用了白色背景，提升了界面的整洁效果。
- **重构**
  - 调整了关闭操作的交互方式，将关闭图标改为更符合语义的按钮元素，增强了键盘操作支持和无障碍体验。
  - 更新了通知配置结构，简化了关闭图标的处理方式，使其更灵活并支持无障碍属性。
- **测试**
  - 在通知组件的测试套件中新增了测试用例，验证关闭按钮的可访问性属性是否正确设置。
  - 修改了现有测试用例，更新了关闭图标的处理逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->