### PR TITLE
fix: Issue 374 notice-wrapper::after Style in stack-expanded

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -239,7 +239,7 @@
             pointer-events: auto;
           }
 
-          &::after {
+          &::before {
             content: "";
             position: absolute;
             left: 0;

--- a/docs/examples/stack.tsx
+++ b/docs/examples/stack.tsx
@@ -15,7 +15,7 @@ const getConfig = () => ({
 });
 
 const Demo = () => {
-  const [{ open }, holder] = useNotification({ motion, stack: true });
+  const [{ open }, holder] = useNotification({ motion, stack: true, closable: true });
 
   return (
     <Context.Provider value={{ name: 'bamboo' }}>


### PR DESCRIPTION
fix the pseudo-element of notice-wrapper cover issue, change pseudo-element  after to before.

close https://github.com/react-component/notification/issues/374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 堆叠通知示例现在支持关闭按钮，用户可手动关闭通知。

* **样式**
  * 优化通知堆叠样式，调整伪元素的位置但不影响视觉效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->