### PR TITLE
feat: adapt semantic close

### DIFF
--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -33,6 +33,8 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
     onNoticeClose,
     times,
     hovering: forcedHovering,
+    classNames,
+    styles,
   } = props;
   const [hovering, setHovering] = React.useState(false);
   const [percent, setPercent] = React.useState(0);
@@ -138,7 +140,8 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
       {/* Close Icon */}
       {closable && (
         <button
-          className={`${noticePrefixCls}-close`}
+          className={clsx(`${noticePrefixCls}-close`, classNames?.close)}
+          style={{ ...styles?.close }}
           onKeyDown={onCloseKeyDown}
           aria-label="Close"
           {...ariaProps}

--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -141,7 +141,7 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
       {closable && (
         <button
           className={clsx(`${noticePrefixCls}-close`, classNames?.close)}
-          style={{ ...styles?.close }}
+          style={styles?.close}
           onKeyDown={onCloseKeyDown}
           aria-label="Close"
           {...ariaProps}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,7 +2,7 @@ import type React from 'react';
 
 export type Placement = 'top' | 'topLeft' | 'topRight' | 'bottom' | 'bottomLeft' | 'bottomRight';
 
-type NoticeSemanticProps = 'wrapper';
+type NoticeSemanticProps = 'wrapper' | 'close';
 
 export interface NoticeConfig {
   content?: React.ReactNode;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -644,8 +644,9 @@ describe('Notification.Basic', () => {
     });
     expect(document.querySelector('.rc-notification-notice-wrapper')).toHaveClass('bamboo');
 
-    expect(document.querySelector('.rc-notification-notice-close')).toHaveClass('custom-close');
-    expect(document.querySelector('.rc-notification-notice-close')).toHaveStyle({
+    const closeButton = document.querySelector('.rc-notification-notice-close');
+    expect(closeButton).toHaveClass('custom-close');
+    expect(closeButton).toHaveStyle({
       color: 'rgb(255, 0, 0)',
     });
   });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -623,13 +623,18 @@ describe('Notification.Basic', () => {
 
     act(() => {
       instance.open({
+        closable: true,
         styles: {
           wrapper: {
             content: 'little',
           },
+          close: {
+            color: 'red',
+          },
         },
         classNames: {
           wrapper: 'bamboo',
+          close: 'custom-close',
         },
       });
     });
@@ -638,6 +643,11 @@ describe('Notification.Basic', () => {
       content: 'little',
     });
     expect(document.querySelector('.rc-notification-notice-wrapper')).toHaveClass('bamboo');
+
+    expect(document.querySelector('.rc-notification-notice-close')).toHaveClass('custom-close');
+    expect(document.querySelector('.rc-notification-notice-close')).toHaveStyle({
+      color: 'rgb(255, 0, 0)',
+    });
   });
 
   it('should className work', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 通知新增可关闭选项（closable：支持布尔或对象）。
  - 支持为关闭按钮单独自定义类名与样式（classNames.close、styles.close），传入值会合并到关闭控件的渲染中。
- 测试
  - 新增用例覆盖可关闭通知及关闭按钮自定义类名与样式的渲染与断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->