### PR TITLE
fix: Clamp duration to setTimeout max value

### DIFF
--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -1,8 +1,15 @@
 import { clsx } from 'clsx';
 import KeyCode from '@rc-component/util/lib/KeyCode';
+import warning from '@rc-component/util/lib/warning';
 import * as React from 'react';
 import type { NoticeConfig } from './interface';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
+
+/**
+ * Maximum delay value for setTimeout in seconds (2^31 - 1 ms).
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value
+ */
+const MAX_DURATION = 2147483647 / 1000;
 
 export interface NoticeProps extends Omit<NoticeConfig, 'onClose'> {
   prefixCls: string;
@@ -38,7 +45,9 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
   const [percent, setPercent] = React.useState(0);
   const [spentTime, setSpentTime] = React.useState(0);
   const mergedHovering = forcedHovering || hovering;
-  const mergedDuration: number = typeof duration === 'number' ? duration : 0;
+
+  const rawDuration: number = typeof duration === 'number' ? duration : 0;
+  const mergedDuration: number = Math.min(rawDuration, MAX_DURATION);
   const mergedShowProgress = mergedDuration > 0 && showProgress;
 
   // ======================== Close =========================
@@ -51,6 +60,14 @@ const Notify = React.forwardRef<HTMLDivElement, NoticeProps & { times?: number }
       onInternalClose();
     }
   };
+
+  // ========================= Warn =========================
+  React.useEffect(() => {
+    warning(
+      rawDuration <= MAX_DURATION,
+      `\`duration\` exceeds the maximum supported value (${MAX_DURATION}s) and has been clamped.`,
+    );
+  }, [rawDuration]);
 
   // ======================== Effect ========================
   React.useEffect(() => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1018,4 +1018,51 @@ describe('Notification.Basic', () => {
       'xxx',
     );
   });
+
+  describe('MAX_DURATION', () => {
+    it('should not warn when duration is within limit', () => {
+      const { instance } = renderDemo();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      act(() => {
+        instance.open({
+          content: <p className="test">1</p>,
+          duration: 0.1,
+        });
+      });
+
+      expect(document.querySelector('.test')).toBeTruthy();
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('should warn and clamp when duration exceeds limit', () => {
+      const { instance } = renderDemo();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const MAX_DURATION = 2147483647 / 1000;
+      const EXCEEDED_DURATION = (2147483647 + 1) / 1000;
+
+      act(() => {
+        instance.open({
+          content: <p className="test">1</p>,
+          duration: EXCEEDED_DURATION,
+        });
+      });
+
+      expect(document.querySelector('.test')).toBeTruthy();
+      expect(errSpy).toHaveBeenCalledWith(
+        `Warning: \`duration\` exceeds the maximum supported value (${MAX_DURATION}s) and has been clamped.`,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(MAX_DURATION * 1000 - 1);
+      });
+      expect(document.querySelector('.test')).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(document.querySelector('.test')).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
## Problem Description

The `setTimeout` used in this component has a [maximum delay limit](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value). If the `duration` exceeds this limit, it overflows and triggers immediately (treated as `0ms`).

This causes issues for Ant Design's `Message` and `Notification` components ([CodeSandbox](https://codesandbox.io/p/github/jynxio/antd-pr-381/main?import=true)):

```tsx
import { App } from 'antd';

const { message } = App.useApp();
const maxDuration = Math.pow(2, 31) - 1; // ms
const exceededDuration = maxDuration + 1; // ms

message.info('', maxDuration / 1000); // ✅ Works: within limit, renders normally
message.info('', exceededDuration / 1000); // ❌ Fails: exceeds limit, closes immediately due to overflow
```

<br />
<br />

## Proposed Solutions

I considered three approaches. **This PR implements Option 2.** Please let me know if you prefer a different approach.

1.  Treat overflow as `0`: The component will never close (duration = 0)
2.  Clamp to max value: Cap the duration at the maximum valid `setTimeout` limit (closes after ~25 days)
3.  Support exact duration: Strictly implement the specified duration using recursive `setTimeout`

> Why not Option 3?
> It has a low ROI (Return on Investment):
> 1.  Complexity: Requires extra code to handle recursion and race conditions
> 2.  Rarity: This is an extreme edge case
> 3.  Sufficiency: Option 2 is practically sufficient for all real-world use cases

<br />
<br />

## Changes

- [x] Implemented Option 2
- [x] Added test cases

<br />
<br />

## Impact

If the `duration` for a `Message` or `Notification` exceeds the limit:

*   Before: The component flashed and disappeared immediately
*   After: The duration is clamped to approximately 25 days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 通知组件现在会将过长的持续时间限制在最大值，超出时会发出警告提示。

* **Tests**
  * 新增测试覆盖持续时间限制和警告机制的验证。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->