### PR TITLE
fix: Continue timing when mouse moves away

### DIFF
--- a/src/NoticeList.tsx
+++ b/src/NoticeList.tsx
@@ -110,9 +110,12 @@ const NoticeList: FC<NoticeListProps> = (props) => {
       });
 
       // Only update if there's a change to avoid unnecessary re-renders
-      if (newHoverKeys.length > 0 || hoverKeys.length > 0) {
-        setHoverKeys(newHoverKeys);
-      }
+      setHoverKeys((prev) => {
+        if (prev.length === newHoverKeys.length && prev.every((k, i) => k === newHoverKeys[i])) {
+          return prev;
+        }
+        return newHoverKeys;
+      });
     });
 
     return () => cancelAnimationFrame(rafId);

--- a/src/NoticeList.tsx
+++ b/src/NoticeList.tsx
@@ -46,7 +46,8 @@ const NoticeList: FC<NoticeListProps> = (props) => {
   const { classNames: ctxCls } = useContext(NotificationContext);
 
   const dictRef = useRef<Record<string, HTMLDivElement>>({});
-  const [latestNotice, setLatestNotice] = useState<HTMLDivElement>(null);
+  const mousePositionRef = useRef<{ x: number; y: number } | null>(null);
+  const [latestNotice, setLatestNotice] = useState<HTMLDivElement | null>(null);
   const [hoverKeys, setHoverKeys] = useState<string[]>([]);
 
   const keys = configList.map((config) => ({
@@ -60,14 +61,62 @@ const NoticeList: FC<NoticeListProps> = (props) => {
 
   const placementMotion = typeof motion === 'function' ? motion(placement) : motion;
 
+  // Track mouse position globally when in stack mode
+  useEffect(() => {
+    if (!stack) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      mousePositionRef.current = { x: e.clientX, y: e.clientY };
+    };
+
+    document.addEventListener('mousemove', handleMouseMove, { passive: true });
+    return () => document.removeEventListener('mousemove', handleMouseMove);
+  }, [stack]);
+
   // Clean hover key
   useEffect(() => {
     if (stack && hoverKeys.length > 1) {
-      setHoverKeys((prev) =>
-        prev.filter((key) => keys.some(({ key: dataKey }) => key === dataKey)),
-      );
+      // Only update if there's a change to avoid unnecessary re-renders
+      setHoverKeys((prev) => {
+        const filtered = prev.filter((key) => keys.some(({ key: dataKey }) => key === dataKey));
+        return filtered.length === prev.length ? prev : filtered;
+      });
     }
   }, [hoverKeys, keys, stack]);
+
+  // Check mouse position when keys change (notification list updates)
+  useEffect(() => {
+    if (!stack || !mousePositionRef.current) return;
+
+    // Use requestAnimationFrame to wait for DOM updates
+    const rafId = requestAnimationFrame(() => {
+      const mousePos = mousePositionRef.current;
+      if (!mousePos) return;
+
+      const newHoverKeys: string[] = [];
+      keys.forEach(({ key: strKey }) => {
+        const element = dictRef.current[strKey];
+        if (element) {
+          const rect = element.getBoundingClientRect();
+          if (
+            mousePos.x >= rect.left &&
+            mousePos.x <= rect.right &&
+            mousePos.y >= rect.top &&
+            mousePos.y <= rect.bottom
+          ) {
+            newHoverKeys.push(strKey);
+          }
+        }
+      });
+
+      // Only update if there's a change to avoid unnecessary re-renders
+      if (newHoverKeys.length > 0 || hoverKeys.length > 0) {
+        setHoverKeys(newHoverKeys);
+      }
+    });
+
+    return () => cancelAnimationFrame(rafId);
+  }, [keys, stack]);
 
   // Force update latest notice
   useEffect(() => {

--- a/tests/stack.test.tsx
+++ b/tests/stack.test.tsx
@@ -1,5 +1,5 @@
 import { useNotification } from '../src';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 require('../assets/index.less');
@@ -85,5 +85,162 @@ describe('stack', () => {
     fireEvent.mouseEnter(document.querySelector('.rc-notification-notice-wrapper'));
     fireEvent.mouseLeave(document.querySelector('.rc-notification-notice-wrapper'));
     expect(document.querySelector('.rc-notification-stack-expanded')).toBeFalsy();
+  });
+});
+
+describe('hover state after closing notice in stack', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should clear hover state and resume timers when closing a hovered notice', () => {
+    const onClose = vi.fn();
+
+    const Demo = () => {
+      const [api, holder] = useNotification({
+        stack: { threshold: 3 },
+      });
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              api.open({
+                content: <div className="context-content">Test</div>,
+                duration: 1,
+                closable: true,
+                onClose,
+              });
+            }}
+          />
+          {holder}
+        </>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    for (let i = 0; i < 4; i++) {
+      act(() => {
+        fireEvent.click(container.querySelector('button'));
+      });
+    }
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(4);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }));
+    });
+
+    // Hover the topmost notification wrapper
+    const wrappers = document.querySelectorAll('.rc-notification-notice-wrapper');
+    act(() => {
+      fireEvent.mouseEnter(wrappers[wrappers.length - 1]);
+    });
+
+    // Timers should be paused while hovering
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(4);
+
+    // Close the hovered notification via close button
+    act(() => {
+      const closeButtons = document.querySelectorAll('.rc-notification-notice-close');
+      fireEvent.click(closeButtons[closeButtons.length - 1]);
+    });
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(3);
+
+    // Flush requestAnimationFrame so hover state recalculation takes effect
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Remaining notices should auto-close since hover state was properly cleared
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(0);
+    expect(onClose).toHaveBeenCalledTimes(4);
+  });
+
+  it('should keep hover state when mouse is still over a notice after close', () => {
+    const mockRect = {
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 300,
+      width: 300,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    };
+    const spy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockReturnValue(mockRect as DOMRect);
+
+    const Demo = () => {
+      const [api, holder] = useNotification({
+        stack: { threshold: 3 },
+      });
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              api.open({
+                content: <div className="context-content">Test</div>,
+                duration: 1,
+                closable: true,
+              });
+            }}
+          />
+          {holder}
+        </>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    for (let i = 0; i < 4; i++) {
+      act(() => {
+        fireEvent.click(container.querySelector('button'));
+      });
+    }
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(4);
+
+    // Mouse position inside the mocked bounding rect
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }));
+    });
+
+    const wrappers = document.querySelectorAll('.rc-notification-notice-wrapper');
+    act(() => {
+      fireEvent.mouseEnter(wrappers[wrappers.length - 1]);
+    });
+
+    // Close the hovered notification
+    act(() => {
+      const closeButtons = document.querySelectorAll('.rc-notification-notice-close');
+      fireEvent.click(closeButtons[closeButtons.length - 1]);
+    });
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(3);
+
+    // Flush RAF - mouse is within bounding rect so hover state should persist
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Timers should still be paused because mouse is detected over a notice
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(document.querySelectorAll('.rc-notification-notice')).toHaveLength(3);
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
### 问题描述
notification 关闭首个通知后，下方通知上移，鼠标移开时倒计时不自动继续

### 复现步骤
1. 点击 “Show custom progress color” 按钮，生成多个堆叠的通知（例如 4 个）。
2. 将鼠标悬浮在最上方的第一个通知上，触发其悬浮倒计时（进度条开始填充）。
3. 在不移动鼠标的情况下，点击该通知的关闭（X）按钮，将其移除。此时下方的通知会上移，原第二个通知成为新的第一个通知。将鼠标光标从通知区域移开。
4. 观察新的最上方通知的进度条：它会停留在关闭首个通知时的进度，不会自动继续倒计时直至关闭。
5. 将鼠标再次移到该通知上，然后移开，倒计时会恢复正常，通知会按预期关闭。

### 关联Antd-Design Issue
https://github.com/ant-design/ant-design/issues/57096

### 修复方案
当通知列表发生变化时，检查鼠标是否仍在通知区域内

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在通知堆叠模式中加入全局鼠标位置跟踪，提升对悬停目标的识别精度
  * 优化悬停交互逻辑，仅在实际变化时更新悬停状态，减少不必要的重渲染

* **测试**
  * 扩充堆叠通知的悬停行为与自动关闭定时器相关测试，覆盖快速创建、悬停与关闭场景
<!-- end of auto-generated comment: release notes by coderabbit.ai -->