### PR TITLE
[codex] support semantic notification slots

### DIFF
--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -11,6 +11,9 @@ export interface NotificationClassNames {
   root?: string;
   icon?: string;
   section?: string;
+  title?: string;
+  description?: string;
+  actions?: string;
   close?: string;
   progress?: string;
 }
@@ -20,6 +23,9 @@ export interface NotificationStyles {
   root?: React.CSSProperties;
   icon?: React.CSSProperties;
   section?: React.CSSProperties;
+  title?: React.CSSProperties;
+  description?: React.CSSProperties;
+  actions?: React.CSSProperties;
   close?: React.CSSProperties;
   progress?: React.CSSProperties;
 }
@@ -42,6 +48,7 @@ export interface NotificationProps {
   description?: React.ReactNode;
   icon?: React.ReactNode;
   actions?: React.ReactNode;
+  role?: string;
   closable?: ClosableType;
   offset?: number;
   notificationIndex?: number;
@@ -78,6 +85,7 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
     description,
     icon,
     actions,
+    role,
     closable,
     offset,
     notificationIndex,
@@ -167,12 +175,19 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
   // ======================== Content =========================
   const titleNode =
     title !== undefined && title !== null ? (
-      <div className={`${noticePrefixCls}-title`}>{title}</div>
+      <div className={clsx(`${noticePrefixCls}-title`, classNames?.title)} style={styles?.title}>
+        {title}
+      </div>
     ) : null;
 
   const descNode =
     description !== undefined && description !== null ? (
-      <div className={`${noticePrefixCls}-description`}>{description}</div>
+      <div
+        className={clsx(`${noticePrefixCls}-description`, classNames?.description)}
+        style={styles?.description}
+      >
+        {description}
+      </div>
     ) : null;
 
   const hasTitle = titleNode !== null;
@@ -204,6 +219,15 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
     );
   }
 
+  const actionsNode = actions ? (
+    <div
+      className={clsx(`${noticePrefixCls}-actions`, classNames?.actions)}
+      style={styles?.actions}
+    >
+      {actions}
+    </div>
+  ) : null;
+
   // ========================= Render =========================
   const mergedStyle: React.CSSProperties & {
     '--notification-index'?: number;
@@ -218,10 +242,13 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
     mergedStyle['--notification-y'] = `${mergedOffset}px`;
   }
 
+  const mergedRole = role ?? rootProps?.role ?? 'alert';
+
   return (
     <div
       {...rootProps}
       ref={ref}
+      role={mergedRole}
       data-notification-index={mergedNotificationIndex}
       // Styles
       className={clsx(noticePrefixCls, className, classNames?.root, {
@@ -235,6 +262,7 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
       onMouseLeave={onInternalMouseLeave}
     >
       {contentNode}
+      {actionsNode}
 
       {mergedClosable && (
         <button
@@ -247,8 +275,6 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
           {closableConfig.closeIcon}
         </button>
       )}
-
-      {actions && <div className="actions">{actions}</div>}
 
       {showProgress && typeof duration === 'number' && duration > 0 && (
         <Progress

--- a/src/NotificationList/index.tsx
+++ b/src/NotificationList/index.tsx
@@ -47,7 +47,17 @@ export interface NotificationListProps {
   onAllRemoved?: (placement: Placement) => void;
 }
 
-const noticeSlotKeys = ['wrapper', 'root', 'icon', 'section', 'close', 'progress'] as const;
+const noticeSlotKeys: (keyof NoticeClassNames)[] = [
+  'wrapper',
+  'root',
+  'icon',
+  'section',
+  'title',
+  'description',
+  'actions',
+  'close',
+  'progress',
+];
 
 function fillClassNames(
   classNamesList: (NotificationClassNames | undefined)[],

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -584,6 +584,46 @@ describe('Notification.Basic', () => {
     expect(notice[0].getAttribute('role')).toBe('alert');
   });
 
+  it('sets role attribute from notification config', () => {
+    const { instance } = renderDemo();
+
+    act(() => {
+      instance.open({
+        title: 'bamboo',
+        description: <span className="test-role-description">simple show</span>,
+        icon: <span className="test-role-icon" />,
+        actions: <button type="button">light</button>,
+        role: 'status',
+        closable: true,
+        showProgress: true,
+        duration: 3,
+      });
+    });
+
+    const notice = document.querySelector('.rc-notification-notice');
+
+    expect(notice).toHaveAttribute('role', 'status');
+    expect(notice.querySelector('.rc-notification-notice-content')).toBeFalsy();
+    expect(notice.querySelector('.rc-notification-notice-title')).toBeTruthy();
+    expect(notice.querySelector('.rc-notification-notice-description')).toBeTruthy();
+    expect(notice.querySelector('.rc-notification-notice-icon')).toBeTruthy();
+    expect(notice.querySelector('.rc-notification-notice-actions')).toBeTruthy();
+    expect(notice.querySelector('.rc-notification-notice-close')).toBeTruthy();
+    expect(notice.querySelector('.rc-notification-notice-progress')).toBeTruthy();
+  });
+
+  it('sets default role attribute', () => {
+    const { instance } = renderDemo();
+
+    act(() => {
+      instance.open({
+        description: <span className="test-default-role">simple show</span>,
+      });
+    });
+
+    expect(document.querySelector('.rc-notification-notice')).toHaveAttribute('role', 'alert');
+  });
+
   it('should style work', () => {
     const { instance } = renderDemo({
       style: () => ({
@@ -692,6 +732,94 @@ describe('Notification.Basic', () => {
       content: 'little',
     });
     expect(document.querySelector('.bamboo')).toHaveClass('bamboo');
+  });
+
+  it('should support semantic content styles and classNames', () => {
+    const { instance } = renderDemo({
+      classNames: {
+        title: 'global-title',
+        description: 'global-description',
+        actions: 'global-actions',
+        icon: 'global-icon',
+      },
+      styles: {
+        title: {
+          content: 'global-title',
+        },
+        description: {
+          content: 'global-description',
+        },
+        actions: {
+          content: 'global-actions',
+        },
+        icon: {
+          content: 'global-icon',
+        },
+      },
+    });
+
+    act(() => {
+      instance.open({
+        title: 'bamboo',
+        description: 'little',
+        icon: <span />,
+        actions: <button type="button">light</button>,
+        classNames: {
+          title: 'notice-title',
+          description: 'notice-description',
+          actions: 'notice-actions',
+          icon: 'notice-icon',
+        },
+        styles: {
+          title: {
+            marginTop: 1,
+          },
+          description: {
+            marginRight: 2,
+          },
+          actions: {
+            marginBottom: 3,
+          },
+          icon: {
+            marginLeft: 4,
+          },
+        },
+      });
+    });
+
+    expect(document.querySelector('.rc-notification-notice-title')).toHaveClass(
+      'global-title',
+      'notice-title',
+    );
+    expect(document.querySelector('.rc-notification-notice-title')).toHaveStyle({
+      content: 'global-title',
+      marginTop: '1px',
+    });
+    expect(document.querySelector('.rc-notification-notice-description')).toHaveClass(
+      'global-description',
+      'notice-description',
+    );
+    expect(document.querySelector('.rc-notification-notice-description')).toHaveStyle({
+      content: 'global-description',
+      marginRight: '2px',
+    });
+    expect(document.querySelector('.rc-notification-notice-actions')).toHaveClass(
+      'global-actions',
+      'notice-actions',
+    );
+    expect(document.querySelector('.rc-notification-notice-actions')).toHaveStyle({
+      content: 'global-actions',
+      marginBottom: '3px',
+    });
+    expect(document.querySelector('.actions')).toBeFalsy();
+    expect(document.querySelector('.rc-notification-notice-icon')).toHaveClass(
+      'global-icon',
+      'notice-icon',
+    );
+    expect(document.querySelector('.rc-notification-notice-icon')).toHaveStyle({
+      content: 'global-icon',
+      marginLeft: '4px',
+    });
   });
 
   it('should className work', () => {


### PR DESCRIPTION
## Summary

- Add `title`, `description`, and `actions` semantic slots to notification classNames/styles types.
- Apply the new slots when rendering title, description, and actions content.
- Render actions with `${noticePrefixCls}-actions` instead of the bare `actions` class.
- Include the new slots in NotificationList className/style merging so root config and per-notice config compose correctly.
- Add coverage for merged semantic slots and the actions class name.

## Why

antd is moving notification content rendering into `@rc-component/notification` and needs these semantic slots to preserve its public `classNames`/`styles` API during the migration.

This keeps the existing icon wrapper slot behavior unchanged, so antd can continue passing its with-icon layout class through `classNames.wrapper` when an icon exists. Role handling remains supported through existing root `props`.

## Validation

- `npm test`
- `npm run lint` (passes with existing hooks warnings)
- `npm run compile` (passes with existing hooks warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 通知组件现支持自定义 `role` 属性，增强无障碍访问支持，默认为 `alert`。
  * 允许对通知的标题、描述和操作按钮分别进行类名和样式自定义。

* **测试**
  * 新增单元测试验证语义化通知渲染和样式覆盖功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->