### PR TITLE
[codex] Support semantic list styles

### DIFF
--- a/src/NotificationList/index.tsx
+++ b/src/NotificationList/index.tsx
@@ -24,10 +24,12 @@ export interface NotificationListConfig extends Omit<NotificationProps, 'prefixC
 }
 
 export interface NotificationClassNames extends NoticeClassNames {
+  list?: string;
   listContent?: string;
 }
 
 export interface NotificationStyles extends NoticeStyles {
+  list?: React.CSSProperties;
   listContent?: React.CSSProperties;
 }
 
@@ -239,6 +241,7 @@ const NotificationList: React.FC<NotificationListProps> = (props) => {
         `${prefixCls}-${placement}`,
         contextClassNames?.list,
         className,
+        classNames?.list,
         {
           [`${prefixCls}-stack`]: stackEnabled,
           [`${prefixCls}-stack-expanded`]: expanded,
@@ -251,7 +254,7 @@ const NotificationList: React.FC<NotificationListProps> = (props) => {
       onMouseLeave={() => {
         setListHovering(false);
       }}
-      style={style}
+      style={{ ...styles?.list, ...style }}
     >
       <Content
         listPrefixCls={listPrefixCls}

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -844,12 +844,16 @@ describe('Notification.Basic', () => {
     expect(document.querySelector('.bamboo-topRight')).toBeTruthy();
   });
 
-  it('should listContent styles and classNames work', () => {
+  it('should list and listContent styles and classNames work', () => {
     const { instance } = renderDemo({
       classNames: {
+        list: 'root-list',
         listContent: 'bamboo',
       },
       styles: {
+        list: {
+          content: 'root-list',
+        },
         listContent: {
           content: 'little',
         },
@@ -860,6 +864,10 @@ describe('Notification.Basic', () => {
       instance.open({});
     });
 
+    expect(document.querySelector('.rc-notification-list')).toHaveStyle({
+      content: 'root-list',
+    });
+    expect(document.querySelector('.rc-notification-list')).toHaveClass('root-list');
     expect(document.querySelector('.rc-notification-list-content')).toHaveStyle({
       content: 'little',
     });


### PR DESCRIPTION
## Summary

- add `list` to notification semantic `classNames` and `styles`
- apply `classNames.list` and `styles.list` to the notification list root node
- extend the list semantic test to cover both `list` and `listContent`

## Why

`listContent` was supported through `useNotification({ classNames, styles })`, but the list root only accepted provider context class names and the placement `className`/`style` props. This makes the semantic API cover the list root consistently.

## Validation

- `npm test -- --run tests/index.test.tsx`
- `npm test`
- `npm run lint` (passes with existing react-hooks warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 通知列表组件现支持列表级别样式和类名自定义，允许对列表容器和内容区域进行更灵活的样式配置。

* **测试**
  * 新增测试用例验证列表级别样式和类名的正确应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->