### PR TITLE
[codex] Fill notification semantic class names

### DIFF
--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -210,7 +210,10 @@ const Notification = React.forwardRef<HTMLDivElement, NotificationProps>((props,
 
   if (icon !== undefined && icon !== null) {
     contentNode = (
-      <div className={classNames?.wrapper} style={styles?.wrapper}>
+      <div
+        className={clsx(`${noticePrefixCls}-wrapper`, classNames?.wrapper)}
+        style={styles?.wrapper}
+      >
         <div className={clsx(`${noticePrefixCls}-icon`, classNames?.icon)} style={styles?.icon}>
           {icon}
         </div>

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -738,10 +738,33 @@ describe('Notification.Basic', () => {
       });
     });
 
-    expect(document.querySelector('.bamboo')).toHaveStyle({
+    expect(document.querySelector('.rc-notification-notice-wrapper')).toHaveStyle({
       content: 'little',
     });
-    expect(document.querySelector('.bamboo')).toHaveClass('bamboo');
+    expect(document.querySelector('.rc-notification-notice-wrapper')).toHaveClass('bamboo');
+  });
+
+  it('should keep default classNames for semantic nodes', () => {
+    const { instance } = renderDemo();
+
+    act(() => {
+      instance.open({
+        title: 'bamboo',
+        description: 'little',
+        icon: <span />,
+        actions: <button type="button">light</button>,
+        closable: true,
+        showProgress: true,
+      });
+    });
+
+    expect(document.querySelector('.rc-notification-notice')).toBeTruthy();
+
+    ['wrapper', 'icon', 'section', 'title', 'description', 'actions', 'close', 'progress'].forEach(
+      (slot) => {
+        expect(document.querySelector(`.rc-notification-notice-${slot}`)).toBeTruthy();
+      },
+    );
   });
 
   it('should support semantic content styles and classNames', () => {


### PR DESCRIPTION
## Summary

- add the missing default `rc-notification-notice-wrapper` class to the wrapper semantic node
- update wrapper semantic assertions to verify custom class names merge with the default class
- add coverage that all Notification semantic nodes keep their default class names

## Validation

- `npm test -- --run tests/index.test.tsx`
- `npm test`
- `npm run lint` (passes with existing react-hooks warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了通知组件的 CSS 类名应用方式，确保包装元素的样式类名前缀和用户提供的自定义类名能够正确应用和组合。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->