### PR TITLE
fix: export notification list types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import Progress from './Progress';
 import Notification from './Notification';
 import NotificationList from './NotificationList';
 import type { ComponentsType, NotificationProps } from './Notification';
+import type { NotificationListConfig } from './NotificationList';
+import type { StackConfig } from './hooks/useStack';
 import type { NotificationProgressProps } from './Progress';
 
 export { useNotification, NotificationProvider, Progress, Notification, NotificationList };
@@ -13,5 +15,7 @@ export type {
   NotificationConfig,
   ComponentsType,
   NotificationProps,
+  NotificationListConfig,
   NotificationProgressProps,
+  StackConfig,
 };


### PR DESCRIPTION
## Summary
- Export `NotificationListConfig` from the package entry.
- Export `StackConfig` from the package entry so downstream Vite builds can import from the esm entry instead of deep paths.

## Validation
- `npm test`
- `npm run compile`
- `npm run lint` (0 errors; existing hooks warnings remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新增特性**
  * 导出 `NotificationListConfig` 和 `StackConfig` 类型，扩展公开的类型 API，为用户提供更完整的类型支持。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/notification/pull/391)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->