### PR TITLE
chore: forbid package es lib imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,13 +2,13 @@ const base = require('@umijs/fabric/dist/eslint');
 
 const restrictedPackageDirectoryImports = [
   '@rc-component/*/es',
-  '@rc-component/*/es/*',
+  '@rc-component/*/es/**',
   '@rc-component/*/lib',
-  '@rc-component/*/lib/*',
+  '@rc-component/*/lib/**',
   'rc-*/es',
-  'rc-*/es/*',
+  'rc-*/es/**',
   'rc-*/lib',
-  'rc-*/lib/*',
+  'rc-*/lib/**',
 ];
 
 module.exports = {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,31 @@
 const base = require('@umijs/fabric/dist/eslint');
 
+const restrictedPackageDirectoryImports = [
+  '@rc-component/*/es',
+  '@rc-component/*/es/*',
+  '@rc-component/*/lib',
+  '@rc-component/*/lib/*',
+  'rc-*/es',
+  'rc-*/es/*',
+  'rc-*/lib',
+  'rc-*/lib/*',
+];
+
 module.exports = {
   ...base,
   rules: {
     ...base.rules,
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: restrictedPackageDirectoryImports,
+            message: 'Do not import package internals from es/lib. Import from the package root.',
+          },
+        ],
+      },
+    ],
     'react/sort-comp': 0,
     'react/require-default-props': 0,
     'jsx-a11y/no-noninteractive-tabindex': 0,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@rc-component/motion": "^1.1.4",
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/NotificationList/index.tsx
+++ b/src/NotificationList/index.tsx
@@ -1,6 +1,6 @@
 import { CSSMotionList } from '@rc-component/motion';
 import type { CSSMotionProps } from '@rc-component/motion';
-import { useComposeRef } from '@rc-component/util/lib/ref';
+import { useComposeRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import useListPosition from '../hooks/useListPosition';

--- a/src/hooks/useClosable.ts
+++ b/src/hooks/useClosable.ts
@@ -1,4 +1,4 @@
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 import * as React from 'react';
 
 export type ClosableConfig = {

--- a/src/hooks/useNoticeTimer.ts
+++ b/src/hooks/useNoticeTimer.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import raf from '@rc-component/util/es/raf';
-import useEvent from '@rc-component/util/es/hooks/useEvent';
+import { raf, useEvent } from '@rc-component/util';
 
 /**
  * Runs the notice auto-close timer and reports progress updates.


### PR DESCRIPTION
## Summary
- Add an ESLint restriction to block package imports from `/es` and `/lib` internals.
- Switch internal `@rc-component/util` usages to the package root entry.
- Upgrade `@rc-component/util` to `^1.11.0` for the new root exports.

## Validation
- `npm run lint` (0 errors; existing hooks warnings remain)
- `npm run compile`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 更新依赖版本以获取最新的工具库功能和改进。
  * 优化内部代码导入结构，采用更标准的模块导入方式。
  * 增强代码质量检查规则，确保项目遵循最佳实践。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/notification/pull/392)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->